### PR TITLE
Bind DN

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,27 +95,19 @@ This authentication backend attempts to be flexible with the way LDAP binding an
 
 #### ActiveDirectory Examples
 
-Using `sAMAccountName` should be unique in combination with a domain name.<br />
-```
-"bind_dn": "sAMAccountName={username}@example.com", "bind_pw": "{password}"
-```
+Using `sAMAccountName` should be unique in combination with a domain name.
+`"bind_dn": "sAMAccountName={username}@example.com", "bind_pw": "{password}"`
 
-Using `userPrincipalName` should be unique within a forest.<br />
-```
-"bind_dn": "userPrincipalName={username}", "bind_pw": "{password}"
-```
+Using `userPrincipalName` should be unique within a forest.
+`"bind_dn": "userPrincipalName={username}", "bind_pw": "{password}"`
 
 #### OpenLDAP Examples
 
 Using anonymous binding
-```
-"bind_dn": "", "bind_pw": ""
-```
+`"bind_dn": "", "bind_pw": ""`
 
 Using bind DN
-```
-"bind_dn": "cn=bind_user,dc=example,dc=com", "bind_pw": "bind_user_password"
-```
+`"bind_dn": "cn=bind_user,dc=example,dc=com", "bind_pw": "bind_user_password"`
 
 
 ### Installation
@@ -123,26 +115,24 @@ Using bind DN
 The procedure mentioned here is suitable for development environments and may not be ideal under production conditions.
 
  1. Activate the stackstorm virtual environment.
- ```source /<path to stackstorm>/st2/bin/activate```
- 2. pip upgrade to latest version of pip
- ```pip install --update pip```
- 3. install dev packages for ldap (optional for development)
- ```apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev```
+ `source /<path to stackstorm>/st2/bin/activate`
+ 2. Upgrade pip to the latest version.
+ `pip install --update pip`
+ 3. Optionally, install dev packages for ldap
+ `apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev`
  4. Install the LDAP plugin and its dependencies.
- ```pip install git+https://github.com/<github_account>/st2-auth-backend-ldap.git@master#egg=st2_auth_backend_ldap```
+ `pip install git+https://github.com/<github_account>/st2-auth-backend-ldap.git@master#egg=st2_auth_backend_ldap`
  5. Deactivate virtual environment.
- ```deactivate```
+ `deactivate`
  6. Configure the authentication backend in `/etc/st2/st2.conf` (see example above).
  7. Restart Stackstorm
- ```st2ctl restart```
+ `st2ctl restart`
 
 Watch out for configuration errors in st2.conf, the auth daemon will silently fail to start if it encounters any errors.
 
 Confirm you can get access with the required information:
-```
-  apt-get install ldap-utils
-  ldapsearch ....
-```
+`  apt-get install ldap-utils
+  ldapsearch ....`
 
 
 ## Copyright, License, and Contributors Agreement

--- a/README.md
+++ b/README.md
@@ -92,13 +92,25 @@ The procedure mentioned here is suitable for development environments and may no
 
  1. Activate the stackstorm virtual environment.
  ```source /<path to stackstorm>/st2/bin/activate```
- 2. Install the LDAP plugin and its dependencies.
+ 2. pip upgrade to latest version of pip
+ ```pip install --update pip```
+ 3. install dev packages for ldap (optional for development)
+ ```apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev```
+ 4. Install the LDAP plugin and its dependencies.
  ```pip install git+https://github.com/<github_account>/st2-auth-backend-ldap.git@master#egg=st2_auth_backend_ldap```
- 3. Deactivate virtual environment.
-```deactivate```
- 4. Configure the authentication backend in `/etc/st2/st2.conf` (see example above).
- 5. Restart Stackstorm
+ 5. Deactivate virtual environment.
+ ```deactivate```
+ 6. Configure the authentication backend in `/etc/st2/st2.conf` (see example above).
+ 7. Restart Stackstorm
  ```st2ctl restart```
+
+Watch out for configuration errors in st2.conf, the auth daemon will silently fail to start if it encounters any errors.
+
+Confirm you can get access with the required information:
+```
+  apt-get install ldap-utils
+  ldapsearch ....
+```
 
 
 ## Copyright, License, and Contributors Agreement
@@ -112,4 +124,3 @@ or at: [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licens
 By contributing you agree that these contributions are your own (or approved by your employer) and
 you grant a full, complete, irrevocable copyright license to all users and developers of the
 project, present and future, pursuant to the license of the project.
-

--- a/README.md
+++ b/README.md
@@ -2,47 +2,50 @@
 
 [![Build Status](https://api.travis-ci.org/StackStorm/st2-auth-backend-ldap.svg?branch=master)](https://travis-ci.org/StackStorm/st2-auth-backend-ldap) [![IRC](https://img.shields.io/irc/%23stackstorm.png)](http://webchat.freenode.net/?channels=stackstorm)
 
-The LDAP backend reads credentials and authenticates user against an LDAP server. This backend
-was originally contributed to st2 repo by [Ruslan Tumarkin](https://github.com/ruslantum) under
-[PR #1790](https://github.com/StackStorm/st2/pull/1790).
+The LDAP backend reads credentials and authenticates user against an LDAP server. This backend was originally contributed to st2 repo by [Ruslan Tumarkin](https://github.com/ruslantum) under [PR #1790](https://github.com/StackStorm/st2/pull/1790).
 
 Note:
 
-Currently there are two types of LDAP backends available - community contributed one and one
-developed and maintained by the StackStorm team. This repository contains a community contributed
-one.
+Currently there are two types of LDAP backends available - community contributed one and one developed and maintained by the StackStorm team. This repository contains a community contributed one.
 
-Community contributed backend can be installed by anyone and the StackStorm developed one is only
-available in the enterprise edition (for more information on the enterprise edition, please see
-https://stackstorm.com/product/#enterprise).
+Community contributed backend can be installed by anyone and the StackStorm developed one is only available in the enterprise edition (for more information on the enterprise edition, please see https://stackstorm.com/product/#enterprise).
 
-The difference between them is that the one included in the enterprise edition is developed,
-supported, tested, maintained and certified by the StackStorm team and the community contributed
-one is developed and maintained by the community.
+The difference between them is that the one included in the enterprise edition is developed, supported, tested, maintained and certified by the StackStorm team and the community contributed one is developed and maintained by the community.
 
 ### Configuration Options
 
 | option        | required | default | description                                                |
 |---------------|----------|---------|------------------------------------------------------------|
-| ldap_server   | yes      |         | URL of the LDAP server                                     |
-| base_dn       | yes      |         | Base DN on the LDAP server                                 |
-| group_dn      | yes      |         | Group DN in which the user is a member                     |
-| scope         | yes      | subtree | Scope search parameter: base, onelevel or subtree          |
-| use_tls       | yes      |         | Boolean parameter to set if tls is required                |
-| search_filter | yes      |         | Filter that should contain the placeholder %(username)s    |
+| ldap_uri      | yes      |         | URI of the LDAP server.  Format: `<protocol>://<hostname>[:port] `(Protocol: `ldap` or `ldaps`) |
+| use_tls       | yes      |         | Boolean parameter to set if tls is required. Should be set to *false* using _ldaps_ in the uri. |
+| bind_dn       | no       |         | DN user to bind to LDAP.  If an empty string, an anonymous bind is performed. To use the user supplied username in the bind_dn, use the `{username}` placeholder in string. |
+| bind_pw       | no       |         | DN password.  Use the `{password}` placeholder in the string to use the user supplied password.|
+| user          | no       |         | Search parameters for user authentication. _see user table below_ |
+| group         | no       |         | Search parameters for user's group membership. _see group table below_ |
+
+#### Attributes for user option
+| option        | required | default | description                                                |
+|---------------|----------|---------|------------------------------------------------------------|
+| base_dn       | yes      |         | Base DN on the LDAP server to be used when lookuping up the user account. |
+| search_filter | yes      |         | Should contain the placeholder `{username}` for the username. |
+| scope         | yes      |         | The scope of the search to be performed. Available choices: _base_, _onelevel_, _subtree_ |
+
+#### Attributes for group option
+| option        | required | default | description                                                |
+|---------------|----------|---------|------------------------------------------------------------|
+| base_dn       | yes      |         | Base DN on the LDAP server to be used when lookuping up the group. |
+| search_filter | yes      |         | Should contain the placeholder `{username}` for the username. |
+| scope         | yes      |         | The scope of the search to be performed. Available choices: _base_, _onelevel_, _subtree_ |
 
 ### Configuration Example
 
-Please refer to the authentication section in the StackStorm
-[documentation](http://docs.stackstorm.com) for basic setup concept. The
-following is an example of the auth section in the StackStorm configuration file for the flat-file
-backend.
+Please refer to the authentication section in the StackStorm [documentation](http://docs.stackstorm.com) for basic setup concept. The following is an example of the auth section in the StackStorm configuration file for the ldap backend.
 
 ```
 [auth]
 mode = standalone
 backend = ldap
-backend_kwargs = {"ldap_server": "ldap://identity.example.com:389", "base_dn": "ou=users,dc=example,dc=com", "group_dn": "ou=devops,ou=groups,dc=example,dc=com", "scope": "subtree", "use_tls": true, "search_filter": ""}
+backend_kwargs = { "ldap_uri": "ldap://ldap.example.com", "use_tls": true, "bind_dn": "cn=user,dc=example,dc=com", "bind_pw": "bind_password", "user": {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}, "group": {"base_dn": "ou=groups,dc=example,dc=com", "search_filter": "(&(cn=st2access)(memberUid={username}))", "scope": "subtree"} }
 enable = True
 use_ssl = True
 cert = /path/to/ssl/cert/file
@@ -52,6 +55,52 @@ api_url = https://myhost.example.com:9101
 debug = False
 ```
 
+### Authenticating users against various schemas.
+
+There is no one standard way to store user credentials in LDAP.  There are various ways to organise the directory tree and various ways to secure it.  In some cases, the users DN can't be determined with a static configuration and requires a bind DN to locate the user in the database before user authentication can occur.
+
+This authentication backend attempts to be flexible with the way LDAP binding and authentication can be performed, but may not meet all use cases.
+
+#### ActiveDirectory Examples
+
+Using `sAMAccountName` should be unique in combination with a domain name.<br />
+```
+"bind_dn": "sAMAccountName={username}@example.com", "bind_pw": "{password}"
+```
+
+Using `userPrincipalName` should be unique within a forest.<br />
+```
+"bind_dn": "userPrincipalName={username}", "bind_pw": "{password}"
+```
+
+#### OpenLDAP Examples
+
+Using anonymous binding
+```
+"bind_dn": "", "bind_pw": ""
+```
+
+Using bind DN
+```
+"bind_dn": "cn=bind_user,dc=example,dc=com", "bind_pw": "bind_user_password"
+```
+
+
+### Installation
+
+The procedure mentioned here is suitable for development environments and may not be ideal under production conditions.
+
+ 1. Activate the stackstorm virtual environment.
+ ```source /<path to stackstorm>/st2/bin/activate```
+ 2. Install the LDAP plugin and its dependencies.
+ ```pip install git+https://github.com/<github_account>/st2-auth-backend-ldap.git@master#egg=st2_auth_backend_ldap```
+ 3. Deactivate virtual environment.
+```deactivate```
+ 4. Configure the authentication backend in `/etc/st2/st2.conf` (see example above).
+ 5. Restart Stackstorm
+ ```st2ctl restart```
+
+
 ## Copyright, License, and Contributors Agreement
 
 Copyright 2015 StackStorm, Inc.
@@ -60,6 +109,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 compliance with the License. You may obtain a copy of the License in the [LICENSE](LICENSE) file,
 or at: [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-By contributing you agree that these contributions are your own (or approved by your employer) and 
+By contributing you agree that these contributions are your own (or approved by your employer) and
 you grant a full, complete, irrevocable copyright license to all users and developers of the
 project, present and future, pursuant to the license of the project.
+

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ The difference between them is that the one included in the enterprise edition i
 
 Please refer to the authentication section in the StackStorm [documentation](http://docs.stackstorm.com) for basic setup concept. The following is an example of the auth section in the StackStorm configuration file for the ldap backend.
 
-```
-[auth]
+`[auth]
 mode = standalone
 backend = ldap
 backend_kwargs = { "ldap_uri": "ldap://ldap.example.com", "use_tls": true, "bind_dn": "cn=user,dc=example,dc=com", "bind_pw": "bind_password", "user": {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}, "group": {"base_dn": "ou=groups,dc=example,dc=com", "search_filter": "(&(cn=st2access)(memberUid={username}))", "scope": "subtree"} }
@@ -53,7 +52,40 @@ key = /path/to/ssl/key/file
 logging = /path/to/st2auth.logging.conf
 api_url = https://myhost.example.com:9101
 debug = False
-```
+`
+
+### Authenticating users against alternative schemas.
+
+There is no one standard way to store user credentials in LDAP.  There are various ways to organise the directory tree and various ways to secure it.  In some cases, the users DN can't be determined with a static configuration and requires a bind DN to locate the user in the database before user authentication can occur.
+
+This authentication backend attempts to be flexible with the way LDAP binding and authentication can be performed, but may not meet all uses cases.
+
+#### ActiveDirectory Examples
+
+Using `sAMAccountName` should be unique in combination with a domain name.<br />
+`"user_dn": "sAMAccountName={{username}}@example.com"`
+
+Using `userPrincipalName` should be unique within a forest.<br />
+`"user_dn": "userPrincipalName={{username}}"`
+
+#### OpenLDAP
+Match unique users in a posix group
+`"uniqueMember=uid=`
+
+### Installation
+
+The procedure mentioned here is suitable for development environments and not recommended for production.
+
+ 1. Activate the stackstorm virtual environment.
+ `source /<path to stackstorm>/st2/bin/activate`
+ 2. Install the LDAP plugin and it's dependencies.
+ `pip install git+https://github.com/StackStorm/st2-auth-backend-ldap.git@master#egg=st2_auth_backend_ldap`
+ 3. Deactivate virtual environment.
+ `deactivate`
+ 4. Configure the authentication backend in `/etc/st2/st2.conf` (see example above).
+ 5. Restart Stackstorm
+ `st2ctl restart`
+
 
 ### Authenticating users against various schemas.
 

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -26,6 +26,7 @@ __all__ = [
     'LDAPAuthenticationBackend'
 ]
 
+
 class LDAPAuthenticationBackend(object):
     """
     Backend which reads authentication information from a ldap server.
@@ -37,17 +38,19 @@ class LDAPAuthenticationBackend(object):
     def __init__(self, ldap_uri, use_tls=False, bind_dn='', bind_pw='', user=None, group=None):
         """
         :param ldap_uri: URL of the LDAP Server. <proto>://<host>[:port]
-        :type ldap_uri: ``str``
-        :param use_tls: Boolean parameter to set if tls is required.
-        :type use_tls: ``bool``
-        :param bind_dn: The Distinguish Name account to bind to the ldap server.
-        :type bind_dn: ``str``
-        :param bind_pw: The Distinguish Name account's password.
-        :type bind_pw: ``str``
-        :param user: Search parameters used to authenticate the user.  (base_dn, search_filter, scope)
-        :type user: ``dict``
-        :param group: Search parameters used to confirm the user is a member of a given group.  (base_dn, search_filter, scope)
-        :type group: ``dict``
+        :type ldap_uri:  ``str``
+        :param use_tls:  Boolean parameter to set if tls is required.
+        :type use_tls:   ``bool``
+        :param bind_dn:  The Distinguish Name account to bind to the ldap server.
+        :type bind_dn:   ``str``
+        :param bind_pw:  The Distinguish Name account's password.
+        :type bind_pw:   ``str``
+        :param user:     Search parameters used to authenticate the user.
+                         (base_dn, search_filter, scope)
+        :type user:      ``dict``
+        :param group:    Search parameters used to confirm the user is a member of a given group.
+                         (base_dn, search_filter, scope)
+        :type group:     ``dict``
         """
         self._ldap_uri = ldap_uri
         self._use_tls = use_tls
@@ -55,7 +58,6 @@ class LDAPAuthenticationBackend(object):
         self._bind_pw = bind_pw
         self._user = user
         self._group = group
-
 
     def _scope_to_ldap_option(self, scope):
         """
@@ -68,8 +70,6 @@ class LDAPAuthenticationBackend(object):
         else:
             opt = ldap.SCOPE_SUBTREE
         return opt
-
-
 
     def authenticate(self, username, password):
         """
@@ -130,7 +130,6 @@ class LDAPAuthenticationBackend(object):
             LOG.debug('LDAP connection closed')
         return True
 
-
     def _ldap_connect(self):
         """
         Prepare ldap object for binding phase.
@@ -150,7 +149,6 @@ class LDAPAuthenticationBackend(object):
             LOG.debug('(_ldap_connect) LDAP Error: %s : Type %s' % (str(e), type(e)))
             return False
 
-
     def _ldap_search(self, connection, username, criteria):
         """
         Perform a search against the LDAP server using an established connection.
@@ -158,7 +156,8 @@ class LDAPAuthenticationBackend(object):
         :type connection: ``LDAPobject``
         :param username: The username to be used in the search filter.
         :type username: ``str``
-        :param criteria: A dictionary of search filter parameters. (base_dn, search_filter, scope, pattern)
+        :param criteria: A dictionary of search filter parameters.
+                         (base_dn, search_filter, scope, pattern)
         :type criteria: ``dict``
         """
         base_dn = criteria['base_dn']
@@ -170,7 +169,6 @@ class LDAPAuthenticationBackend(object):
         # Disabled to prevent logging sensitive data.
         # LOG.debug("RESULT: {}".format(result))
         return result
-
 
     def get_user(self, username):
         pass

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -18,24 +18,18 @@
 # pylint: disable=no-member
 
 from __future__ import absolute_import
-
-import logging
-
 import ldap
+import logging
+LOG = logging.getLogger(__name__)
 
 __all__ = [
     'LDAPAuthenticationBackend'
 ]
 
 
-LOG = logging.getLogger(__name__)
-
-
-
 class LDAPAuthenticationBackend(object):
     """
     Backend which reads authentication information from a ldap server.
-
     Supported authentication methods:
         * Anonymous session with user lookup.
         * Bind Distinguish Name with user lookup.
@@ -77,6 +71,7 @@ class LDAPAuthenticationBackend(object):
         return opt
 
 
+
     def authenticate(self, username, password):
         """
         Simple binding to authenticate username/password against the LDAP server.
@@ -88,7 +83,6 @@ class LDAPAuthenticationBackend(object):
         connection = self._ldap_connect()
         if not connection:
             return False
-
         try:
             if self._bind_dn == '' == self._bind_pw:
                 LOG.debug("Attempting to fast bind anonymously.")

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -27,76 +27,157 @@ __all__ = [
     'LDAPAuthenticationBackend'
 ]
 
+
 LOG = logging.getLogger(__name__)
+
 
 
 class LDAPAuthenticationBackend(object):
     """
     Backend which reads authentication information from a ldap server.
-    The backend tries to bind the ldap user with given username and password.
-    If the bind was successful, it tries to find the user in the given group.
-    If the user is in the group, he will be authenticated.
-    """
 
-    def __init__(self, ldap_server, base_dn, group_dn, scope, use_tls, search_filter):
+    Supported authentication methods:
+        * Anonymous session with user lookup.
+        * Bind Distinguish Name with user lookup.
+        * Bind Distinguish Name with user and group lookup.
+    """
+    def __init__(self, ldap_uri, use_tls=False, bind_dn='', bind_pw='', user=None, group=None):
         """
-        :param ldap_server: URL of the LDAP Server
-        :type ldap_server: ``str``
-        :param base_dn: Base DN on the LDAP Server
-        :type base_dn: ``str``
-        :param group_dn: Group DN on the LDAP Server which contains the user as member
-        :type group_dn: ``str``
-        :param scope: Scope search parameter. Can be base, onelevel or subtree (default: subtree)
-        :type scope: ``str``
-        :param use_tls: Boolean parameter to set if tls is required
+        :param ldap_uri: URL of the LDAP Server. <proto>://<host>[:port]
+        :type ldap_uri: ``str``
+        :param use_tls: Boolean parameter to set if tls is required.
         :type use_tls: ``bool``
-        :param search_filter: Should contain the placeholder %(username)s for the username
-        :type use_tls: ``str``
+        :param bind_dn: The Distinguish Name account to bind to the ldap server.
+        :type bind_dn: ``str``
+        :param bind_pw: The Distinguish Name account's password.
+        :type bind_pw: ``str``
+        :param user: Search parameters used to authenticate the user.  (base_dn, search_filter, scope)
+        :type user: ``dict``
+        :param group: Search parameters used to confirm the user is a member of a given group.  (base_dn, search_filter, scope)
+        :type group: ``dict``
         """
-        self._ldap_server = ldap_server
-        self._base_dn = base_dn
-        self._group_dn = group_dn
-        if "base" in scope:
-            self._scope = ldap.SCOPE_BASE
-        elif "onelevel" in scope:
-            self._scope = ldap.SCOPE_ONELEVEL
+        self._ldap_uri = ldap_uri
+        self._use_tls = use_tls
+        self._bind_dn = bind_dn
+        self._bind_pw = bind_pw
+        self._user = user
+        self._group = group
+
+
+    def _scope_to_ldap_option(self, scope):
+        """
+        Transform scope string into ldap module constant.
+        """
+        if "base" in scope.lower():
+            opt = ldap.SCOPE_BASE
+        elif "onelevel" in scope.lower():
+            opt = ldap.SCOPE_ONELEVEL
         else:
-            self._scope = ldap.SCOPE_SUBTREE
-        if use_tls != "True" or "ldaps" in ldap_server:
-            self._use_tls = False
-        else:
-            self._use_tls = True
-        self._search_filter = search_filter
+            opt = ldap.SCOPE_SUBTREE
+        return opt
+
 
     def authenticate(self, username, password):
-        if self._search_filter:
-            search_filter = self._search_filter % {'username': username}
-        else:
-            search_filter = 'uniqueMember=uid=' + username + ',' + self._base_dn
+        """
+        Simple binding to authenticate username/password against the LDAP server.
+        :param username: username to authenticate.
+        :type username: ``str``
+        :param password: password to use with for authentication.
+        :type password: ``str``
+        """
+        connection = self._ldap_connect()
+        if not connection:
+            return False
+
         try:
-            ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
-            connect = ldap.initialize(self._ldap_server)
-            connect.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
-            if self._use_tls:
-                connect.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)
-                connect.start_tls_s()
-                LOG.debug('using TLS')
-            connect.simple_bind_s("uid=" + username + "," + self._base_dn, password)
-            try:
-                result = connect.search_s(self._group_dn, self._scope, search_filter)
-                if result is None:
-                    LOG.debug('User "%s" doesn\'t exist in group "%s"' % (username, self._group_dn))
-                elif result:
-                    LOG.debug('Authentication for user "%s" successful' % (username))
-                    return True
-                return False
-            except:
-                return False
-            finally:
-                connect.unbind()
+            if self._bind_dn == '' == self._bind_pw:
+                LOG.debug("Attempting to fast bind anonymously.")
+                connection.simple_bind_s()
+                LOG.debug("Connected to LDAP as %s " % connection.whoami_s())
+            else:
+                LOG.debug("Attempting to fast bind with DN.")
+                if self._bind_dn.find('{username}') != -1:
+                    self._bind_dn = self._bind_dn.format(username=username)
+                if self._bind_pw.find('{password}') != -1:
+                    self._bind_pw = self._bind_pw.format(password=password)
+
+                connection.simple_bind_s(self._bind_dn, self._bind_pw)
+                LOG.debug("Connected to LDAP as %s " % connection.whoami_s())
+
+            if self._user:
+                # Authenticate username and password.
+                result = self._ldap_search(connection, username, self._user)
+                if len(result) != 1:
+                    LOG.debug("Failed to uniquely identify the user.")
+                    return False
+                user_dn = result[0][0]
+                LOG.debug("DN identified as : %s" % user_dn)
+                try:
+                    user_connection = self._ldap_connect()
+                    user_connection.simple_bind_s(user_dn, password)
+                except ldap.LDAPError as e:
+                    LOG.debug('LDAP Error: %s' % (str(e)))
+                    return False
+                finally:
+                    user_connection.unbind()
+                LOG.debug("User successfully authenticated as %s " % connection.whoami_s())
+
+            if self._group:
+                # Confirm the user is a member of a given group.
+                result = self._ldap_search(connection, username, self._group)
+                if len(result) != 1:
+                    LOG.debug("Unable to find %s in the group." % username)
+                    return False
+
         except ldap.LDAPError as e:
             LOG.debug('LDAP Error: %s' % (str(e)))
             return False
+        finally:
+            connection.unbind()
+            LOG.debug("LDAP connection closed")
+        return True
+
+
+    def _ldap_connect(self):
+        """
+        Prepare ldap object for binding phase.
+        """
+        try:
+            connection = ldap.initialize(self._ldap_uri)
+            ldap.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+            if self._use_tls:
+                # Require TLS connection.
+                ldap.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)
+                # Require server certificate but ignore it's validity. (allow self-signed)
+                ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+                connection.start_tls_s()
+                LOG.debug('Connection now using TLS')
+            return connection
+        except ldap.LDAPError as e:
+            LOG.debug('LDAP Error: %s' % (str(e)))
+            return False
+
+
+    def _ldap_search(self, connection, username, criteria):
+        """
+        Perform a search against the LDAP server using an established connection.
+        :param connection: The established LDAP connection.
+        :type connection: ``LDAPobject``
+        :param username: The username to be used in the search filter.
+        :type username: ``str``
+        :param criteria: A dictionary of search filter parameters. (base_dn, search_filter, scope, pattern)
+        :type criteria: ``dict``
+        """
+        base_dn = criteria["base_dn"]
+        search_filter = criteria["search_filter"].format(username=username)
+        scope = self._scope_to_ldap_option(criteria["scope"])
+
+        LOG.debug("Searching ... %s %s %s" % (base_dn, scope, search_filter))
+        result = connection.search_st(base_dn, scope, search_filter, timeout=10)
+        # Disabled to prevent logging sensitive data.
+        #LOG.debug("RESULT: %s" % result)
+        return result
+
 
     def get_user(self, username):
         pass

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 unittest2
 mock>=1.0
+mockldap>=0.2.8
 pep8>=1.6.0,<1.7
 flake8>=2.3.0,<2.4
 pylint>=1.4.3,<1.5

--- a/tests/unit/test_ldap_backend.py
+++ b/tests/unit/test_ldap_backend.py
@@ -1,0 +1,233 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import ldap
+import os
+import unittest2
+from mockldap import MockLdap
+from st2auth_ldap_backend.ldap_backend import LDAPAuthenticationBackend
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+class LDAPAuthenticationBackendTestCase(unittest2.TestCase):
+    """
+    A simple test case showing off some of the basic features of mockldap.
+    """
+    directory = {
+        'dc=com': {'dc': ['com']},
+        'dc=example,dc=com': {'dc': ['example']},
+        'ou=users,dc=example,dc=com': {'ou': ['users'], 'objectClass': ['groupOfNames'], 'member': ['uid=sarah_connor,ou=users,dc=example,dc=com', 'uid=john_connor,ou=users,dc=example,dc=com']},
+        'cn=manager,dc=example,dc=com': {'cn': ['manager'], 'userPassword': ['ldaptest']},
+        'uid=sarah_connor,ou=users,dc=example,dc=com': { 'uid': ['sarah_connor'], 'userPassword': ['Reece4ever'], 'objectclass': ['inetOrgPerson', 'posixAccount', 'person', 'top'] },
+        'uid=john_connor,ou=users,dc=example,dc=com': { 'uid': ['john_connor'], 'userPassword': ['HastaLavista'], 'objectclass': ['inetOrgPerson', 'posixAccount', 'person', 'top'] },
+        'cn=resistance,ou=groups,dc=example,dc=com': { 'cn': ['resistance'], 'description': ['memberOf'], 'memberuid': ['sarah_connor', 'john_connor'], 'objectclass': ['posixGroup', 'top']}
+    }
+
+
+    @classmethod
+    def setUpClass(cls):
+        # We only need to create the MockLdap instance once. The content we
+        # pass in will be used for all LDAP connections.
+        cls.mockldap = MockLdap(cls.directory)
+
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mockldap
+
+    def setUp(self):
+        # Patch ldap.initialize
+        self.mockldap.start()
+        self.ldapobj = self.mockldap['ldap://fakeldap.example.com/']
+
+    def tearDown(self):
+        # Stop patching ldap.initialize and reset state.
+        self.mockldap.stop()
+        del self.ldapobj
+
+
+    def test_bind_anonymous(self):
+        result = _do_simple_bind('ldap://fakeldap.example.com/', '', '')
+
+        self.assertEquals(self.ldapobj.methods_called(), ['initialize', 'simple_bind_s', 'whoami_s', 'unbind'])
+        self.assertTrue(result)
+
+
+    def test_bind_dn_valid(self):
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'ldaptest')
+
+        self.assertEquals(self.ldapobj.methods_called(), ['initialize', 'simple_bind_s', 'whoami_s', 'unbind'])
+        self.assertTrue(result)
+
+
+    def test_bind_dn_invalid_user(self):
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'uid=invalid_user,ou=users,dc=example,dc=com', 'none')
+
+        self.assertEquals(self.ldapobj.methods_called(), ['initialize', 'simple_bind_s', 'unbind'])
+        self.assertFalse(result)
+
+
+    def test_bind_dn_invalid_password(self):
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'invalid_password')
+
+        self.assertEquals(self.ldapobj.methods_called(), ['initialize', 'simple_bind_s', 'unbind'])
+        self.assertFalse(result)
+
+    def test_search_valid_username(self):
+        username = 'sarah_connor'
+        password = 'Reece4ever'
+        user_dn = 'uid={},ou=users,dc=example,dc=com'.format(username)
+
+        mock_res = (user_dn, LDAPAuthenticationBackendTestCase.directory[user_dn])
+
+        user = {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}
+
+        self.ldapobj.search_s.seed(user["base_dn"], ldap.SCOPE_ONELEVEL, user["search_filter"].format(username=username))([mock_res])
+
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'ldaptest', user_search=user, group_search=None, username=username, password=password)
+
+        self.assertEquals(self.ldapobj.methods_called(), [
+            'initialize',
+            'simple_bind_s',
+            'whoami_s',
+            'search_s',
+            'initialize',
+            'simple_bind_s',
+            'whoami_s',
+            'unbind',
+            'unbind'
+            ]
+        )
+        self.assertTrue(result)
+
+
+    def test_search_invalid_username(self):
+        username = 'invalid_username'
+        password = 'Reece4ever'
+        user = {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}
+
+        mock_res = []
+
+        self.ldapobj.search_s.seed(user["base_dn"], ldap.SCOPE_ONELEVEL, user["search_filter"].format(username=username))(mock_res)
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'ldaptest', user_search=user, group_search=None, username=username, password=password)
+
+        self.assertEquals(self.ldapobj.methods_called(), [
+                'initialize',
+                'simple_bind_s',
+                'whoami_s',
+                'search_s',
+                'unbind'
+            ]
+        )
+        self.assertFalse(result)
+
+
+    def test_search_invalid_password(self):
+        username = 'sarah_connor'
+        password = 'bad_password'
+        user = {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}
+
+        mock_res = []
+
+        self.ldapobj.search_s.seed(user["base_dn"], ldap.SCOPE_ONELEVEL, user["search_filter"].format(username=username))(mock_res)
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'ldaptest', user_search=user, group_search=None, username=username, password=password)
+
+        self.assertEquals(self.ldapobj.methods_called(), [
+                'initialize',
+                'simple_bind_s',
+                'whoami_s',
+                'search_s',
+                'unbind'
+            ]
+        )
+        self.assertFalse(result)
+
+
+    def test_search_valid_username_valid_group(self):
+        username = 'john_connor'
+        password = 'HastaLavista'
+        user_dn = 'uid={},ou=users,dc=example,dc=com'.format(username)
+        mock_user_res = (user_dn, LDAPAuthenticationBackendTestCase.directory[user_dn])
+
+        groupname = 'resistance'
+        group_dn = 'cn={groupname},ou=groups,dc=example,dc=com'.format(groupname=groupname)
+        mock_group_res = (group_dn, LDAPAuthenticationBackendTestCase.directory[group_dn])
+
+        user = {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}
+        group = {"base_dn": "ou=groups,dc=example,dc=com", "search_filter": "(&(cn=%s)(memberUid={username}))"%groupname, "scope": "subtree"}
+
+        self.ldapobj.search_s.seed(user["base_dn"], ldap.SCOPE_ONELEVEL, user["search_filter"].format(username=username))([mock_user_res])
+        self.ldapobj.search_s.seed(group["base_dn"], ldap.SCOPE_SUBTREE, group["search_filter"].format(username=username))([mock_group_res])
+
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'ldaptest', user_search=user, group_search=group, username=username, password=password)
+
+        self.assertEquals(self.ldapobj.methods_called(), [
+                'initialize',
+                'simple_bind_s',
+                'whoami_s',
+                'search_s',
+                'initialize',
+                'simple_bind_s',
+                'whoami_s',
+                'unbind',
+                'search_s',
+                'unbind'
+            ]
+        )
+        self.assertTrue(result)
+
+
+    def test_search_valid_username_invalid_group(self):
+        username = 'john_connor'
+        password = 'HastaLavista'
+        user_dn = 'uid={},ou=users,dc=example,dc=com'.format(username)
+        mock_user_res = (user_dn, LDAPAuthenticationBackendTestCase.directory[user_dn])
+
+        groupname = 'invalid_group'
+        group_dn = 'cn={groupname},ou=groups,dc=example,dc=com'.format(groupname=groupname)
+        mock_group_res = []
+
+        user = {"base_dn": "ou=users,dc=example,dc=com", "search_filter": "(uid={username})", "scope": "onelevel"}
+        group = {"base_dn": "ou=groups,dc=example,dc=com", "search_filter": "(&(cn=%s)(memberUid={username}))"%groupname, "scope": "subtree"}
+
+        self.ldapobj.search_s.seed(user["base_dn"], ldap.SCOPE_ONELEVEL, user["search_filter"].format(username=username))([mock_user_res])
+        self.ldapobj.search_s.seed(group["base_dn"], ldap.SCOPE_SUBTREE, group["search_filter"].format(username=username))(mock_group_res)
+
+        result = _do_simple_bind('ldap://fakeldap.example.com/', 'cn=manager,dc=example,dc=com', 'ldaptest', user_search=user, group_search=group, username=username, password=password)
+
+        self.assertEquals(self.ldapobj.methods_called(), [
+                'initialize',
+                'simple_bind_s',
+                'whoami_s',
+                'search_s',
+                'initialize',
+                'simple_bind_s',
+                'whoami_s',
+                'unbind',
+                'search_s',
+                'unbind'
+            ]
+        )
+        self.assertFalse(result)
+
+
+def _do_simple_bind(uri, bind_dn, bind_pw, user_search=None, group_search=None, username=None, password=None):
+    backend = LDAPAuthenticationBackend(uri, use_tls=False, bind_dn=bind_dn, bind_pw=bind_pw, user=user_search, group=group_search)
+    return backend.authenticate(username, password)
+
+
+if __name__ == '__main__':
+    sys.exit(unittest2.main())


### PR DESCRIPTION
This patch allows the possibility of doing the following:
 1. Binding against the LDAP server with a DN different from the username. (simple bind/anonymous bind)
 2. Authenticate username against a different branch in the directory tree from the bind DN.
 3. Optionally verify the username is a member of a particular group.