### PR TITLE
adding the processing to exclude objects typed 'ldap.RES_SEARCH_REFERENCE' to the search processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The difference between them is that the one included in the enterprise edition i
 | bind_pw       | no       |  ""     | DN password.  Use the `{password}` placeholder in the string to use the user supplied password.|
 | user          | no       |  None   | Search parameters for user authentication. _see user table below_ |
 | group         | no       |  None   | Search parameters for user's group membership. _see group table below_ |
+| ref_hop_limit | no       |  0      | The maximum number to refer Referrals recursively |
 
 #### Attributes for user option
 | option        | required | default | description                                                |

--- a/st2auth_ldap_backend/__init__.py
+++ b/st2auth_ldap_backend/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     'LDAPAuthenticationBackend'
 ]
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -93,25 +93,20 @@ class LDAPAuthenticationBackend(object):
         Therefore, this method parses LDAP tree by calling 'result()' method recursively.
         """
         results = []
-        r_type, r_data = connection.result(result_id, all=0)
+        r_type = None
 
-        if r_type == ldap.RES_SEARCH_ENTRY:
-            results.append(self._get_ldap_search_entry(r_data))
+        while r_type != ldap.RES_SEARCH_RESULT:
+            r_type, r_data = connection.result(result_id, all=0)
 
-            _results = self._get_ldap_search_results(connection, username, criteria, result_id,
-                                                     current_ref_hop)
-            # This condition prevents to append empty results.
-            if _results:
-                results.append(_results)
-        elif r_type == ldap.RES_SEARCH_REFERENCE:
-            _results = self._get_ldap_search_referral(r_data, username, criteria, current_ref_hop)
-            if _results:
-                results.append(_results)
-
-            _results = self._get_ldap_search_results(connection, username, criteria, result_id,
-                                                     current_ref_hop)
-            if _results:
-                results.append(_results)
+            if r_type == ldap.RES_SEARCH_ENTRY:
+                results.append(self._get_ldap_search_entry(r_data))
+            elif r_type == ldap.RES_SEARCH_REFERENCE:
+                _results = self._get_ldap_search_referral(r_data,
+                                                          username,
+                                                          criteria,
+                                                          current_ref_hop)
+                if _results:
+                    results.append(_results)
 
         return results
 

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -122,6 +122,9 @@ class LDAPAuthenticationBackend(object):
 
         results = []
         if referral_info and len(referral_info.groups()) == 2:
+            # save original '_ldap_uri' parameter
+            _original_ldap_uri = self._ldap_uri
+
             # update connection informations to referral's one
             self._ldap_uri = referral_info.group(1)
             _criteria['base_dn'] = referral_info.group(2)
@@ -143,6 +146,9 @@ class LDAPAuthenticationBackend(object):
                     LOG.debug('LDAP Error: %s' % (str(e)))
                 finally:
                     referral_conn.unbind()
+
+            # retrieve original parameter
+            self._ldap_uri = _original_ldap_uri
 
         return results
 

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -165,10 +165,13 @@ class LDAPAuthenticationBackend(object):
         scope = self._scope_to_ldap_option(criteria['scope'])
 
         LOG.debug('Searching ... %s %s %s' % (base_dn, scope, search_filter))
-        result = connection.search_s(base_dn, scope, search_filter)
+        results = connection.search_s(base_dn, scope, search_filter)
+
         # Disabled to prevent logging sensitive data.
         # LOG.debug("RESULT: {}".format(result))
-        return result
+
+        # screening the results from objects of ldap.RES_SEARCH_REFERENCE
+        return [x for x in results if x[0]]
 
     def get_user(self, username):
         pass


### PR DESCRIPTION
This is the correction of #6.

The [`LDAPObject.search_s`](https://www.python-ldap.org/doc/html/ldap.html#ldap.LDAPObject.search_s) returns the objects that are the one typed `ldap.RES_SEARCH_ENTRY` and another one typed `ldap.RES_SEARCH_REFERENCE`.

The implementation of `LDAPAuthenticationBackend` assumes that the former is returned.
So, I corrected the `_ldap_search` method to screen out the objects typed `ldap.RES_SEARCH_REFERENCE`.

__Notes__:
To screen more accurate, I think it's good to use [LDAPObject.result](https://www.python-ldap.org/doc/html/ldap.html#ldap.LDAPObject.result) method. Because we can check objects of its type sequentially by this method. But [mockldap](https://bitbucket.org/psagers/mockldap) doesn't support it ([this ignores sequential flag of 'all'](https://bitbucket.org/psagers/mockldap/src/8a83569d4b2f250fd4384e3aca5530c8baa21965/src/mockldap/ldapobject.py?at=default&fileviewer=file-view-default#ldapobject.py-115:118)). So I made the checker simple, involuntarily.
When the `result` method of `mockldap` is corrected, I should be able to refactor it.

Thank you.