### PR TITLE
Fix #14 - Allow searching from Active Directory root

### DIFF
--- a/dist_utils.py
+++ b/dist_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+import os
 import re
 import sys
 
@@ -22,14 +25,32 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',
-    'fetch_requirements'
+    'fetch_requirements',
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -50,23 +71,37 @@ def fetch_requirements(requirements_file_path):
     links = []
     reqs = []
     for req in parse_requirements(requirements_file_path, session=False):
-        if getattr(req, 'link', None):
+        if req.link:
             links.append(str(req.link))
         reqs.append(str(req.req))
     return (reqs, links)
 
 
-def parse_version_string(file_path):
+def apply_vagrant_workaround():
     """
-    Parse __version__ = 'xxx' from the specifed file
+    Function which detects if the script is being executed inside vagrant and if it is, it deletes
+    "os.link" attribute.
+    Note: Without this workaround, setup.py sdist will fail when running inside a shared directory
+    (nfs / virtualbox shared folders).
     """
-    version = None
-    with open(file_path, 'r') as fd:
-        match = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                          fd.read(), re.MULTILINE)
-    if match:
-        version = match.group(1)
-    else:
-        raise Exception('File %s doesn\'t contain __version__ = \'x.y.z\' string')
+    if os.environ.get('USER', None) == 'vagrant':
+        del os.link
 
-    return version
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2auth_ldap_backend/ldap_backend.py
+++ b/st2auth_ldap_backend/ldap_backend.py
@@ -105,7 +105,7 @@ class LDAPAuthenticationBackend(object):
 
             if r_type == ldap.RES_SEARCH_ENTRY:
                 results.append(self._get_ldap_search_entry(r_data))
-            elif r_type == ldap.RES_SEARCH_REFERENCE:
+            elif self._chase_referrals and r_type == ldap.RES_SEARCH_REFERENCE:
                 _results = self._get_ldap_search_referral(r_data,
                                                           username,
                                                           criteria,

--- a/tests/unit/test_ldap_backend.py
+++ b/tests/unit/test_ldap_backend.py
@@ -276,7 +276,7 @@ class LDAPAuthenticationBackendTestCase(unittest2.TestCase):
         expected_methods_called = (
             self.connect_methods +
             ['simple_bind_s', 'whoami_s', 'search', 'result', 'result'] +
-            self.connect_methods + 
+            self.connect_methods +
             ['simple_bind_s', 'whoami_s', 'unbind', 'search', 'result', 'unbind']
         )
 
@@ -302,9 +302,9 @@ class LDAPAuthenticationBackendTestCase(unittest2.TestCase):
                                  ref_hop_limit=1)
 
         expected_methods_called = (
-            self.connect_methods + 
+            self.connect_methods +
             ['simple_bind_s', 'whoami_s', 'search', 'result', 'result', 'result'] +
-            self.connect_methods + 
+            self.connect_methods +
             ['simple_bind_s', 'whoami_s', 'unbind', 'unbind']
         )
 
@@ -330,9 +330,9 @@ class LDAPAuthenticationBackendTestCase(unittest2.TestCase):
                                  ref_hop_limit=0)
 
         expected_methods_called = (
-            self.connect_methods + 
+            self.connect_methods +
             ['simple_bind_s', 'whoami_s', 'search', 'result', 'result', 'result'] +
-            self.connect_methods + 
+            self.connect_methods +
             ['simple_bind_s', 'whoami_s', 'unbind', 'unbind']
         )
 
@@ -355,7 +355,7 @@ class LDAPAuthenticationBackendTestCase(unittest2.TestCase):
             "scope": "subtree",
         }
 
-        # This is a case that maximum referral hop will be exceeded
+        # This is a case that will return a reference, but chase_referrals is False
         result = _do_simple_bind('', '',
                                  user_search=user, group_search=None,
                                  username='john_connor', password='HastaLavista',

--- a/tests/unit/test_ldap_backend.py
+++ b/tests/unit/test_ldap_backend.py
@@ -342,8 +342,41 @@ class LDAPAuthenticationBackendTestCase(unittest2.TestCase):
         self.assertTrue(re.match(r'^Referral hop limit is exceeded',
                                  self.log_handler.messages['warning'][0]))
 
-def _do_simple_bind(bind_dn, bind_pw, uri=DEFAULT_URI, user_search=None, group_search=None, username=None, password=None, ref_hop_limit=0):
-    backend = LDAPAuthenticationBackend(uri, use_tls=False, bind_dn=bind_dn, bind_pw=bind_pw, user=user_search, group=group_search, ref_hop_limit=ref_hop_limit)
+    @mock.patch('st2auth_ldap_backend.ldap_backend.LDAPAuthenticationBackend._get_ldap_search_referral')
+    def test_search_with_reference_result_but_chase_referrals_false(self, mock_search_referral):
+        # This is for returning the referral object at calling 'result' method of LDAPObject
+        self.mock_referral = [
+            (None, ['ldap://fakeldap2.example.com/ou=cyberdyne,dc=example,dc=com']),
+        ]
+
+        user = {
+            "base_dn": "ou=users,dc=example,dc=com",
+            "search_filter": "(uid={username})",
+            "scope": "subtree",
+        }
+
+        # This is a case that maximum referral hop will be exceeded
+        result = _do_simple_bind('', '',
+                                 user_search=user, group_search=None,
+                                 username='john_connor', password='HastaLavista',
+                                 chase_referrals=False)
+
+        expected_methods_called = (
+            self.connect_methods +
+            ['simple_bind_s', 'whoami_s', 'search', 'result', 'result', 'result'] +
+            self.connect_methods +
+            ['simple_bind_s', 'whoami_s', 'unbind', 'unbind']
+        )
+
+        self.assertEquals(self.ldapobj.methods_called(), expected_methods_called)
+        self.assertTrue(result)
+        self.assertEqual(len(self.log_handler.messages['warning']), 0)
+
+        # ensure that the referral code was never called
+        mock_search_referral.assert_not_called()
+
+def _do_simple_bind(bind_dn, bind_pw, uri=DEFAULT_URI, user_search=None, group_search=None, username=None, password=None, ref_hop_limit=0, chase_referrals=True):
+    backend = LDAPAuthenticationBackend(uri, use_tls=False, bind_dn=bind_dn, bind_pw=bind_pw, user=user_search, group=group_search, ref_hop_limit=ref_hop_limit, chase_referrals=chase_referrals)
     return backend.authenticate(username, password)
 
 


### PR DESCRIPTION
Closes #14 

This prevents the referral result code from being called when `chase_referrals = False`.

This allows us to search Active Directory from the root without the `st2auth` service hanging.